### PR TITLE
Add Windows Tkinter OpenAI Codex desktop app with OAuth and model sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 ## Швидкий старт (Windows)
 
 1. Встанови Python 3.10+.
-2. Один раз задай OAuth client id:
-   - `setx OPENAI_OAUTH_CLIENT_ID "your_client_id_here"`
-3. Запусти додаток:
+2. Запусти додаток:
    - `run_windows.bat`
-4. Натисни `Login with OpenAI`, залогінься в браузері.
-5. Натисни `Refresh models` (або після OAuth список оновиться автоматично).
-6. Пиши prompt і тисни `Run`.
+3. Натисни `Login with OpenAI`, залогінься в браузері.
+4. Натисни `Refresh models` (або після OAuth список оновиться автоматично).
+5. Пиши prompt і тисни `Run`.
+
+> `OPENAI_OAUTH_CLIENT_ID` тепер **не обов'язковий**: додаток працює в auto-mode і передає `client_id` лише якщо він заданий.
 
 ## Моделі
 
@@ -32,6 +32,7 @@
 - `OPENAI_API_KEY`
 - `OPENAI_OAUTH_TOKEN`
 - `OPENAI_MODEL`
+- `OPENAI_OAUTH_CLIENT_ID` (опціонально; додається автоматично, якщо задано)
 - `OPENAI_OAUTH_AUTH_URL` (default: `https://auth.openai.com/oauth/authorize`)
 - `OPENAI_OAUTH_TOKEN_URL` (default: `https://auth.openai.com/oauth/token`)
 - `OPENAI_OAUTH_SCOPES` (default: `openid profile email`)

--- a/README.md
+++ b/README.md
@@ -2,38 +2,30 @@
 
 Сучасний desktop-клієнт OpenAI Codex для Windows на `tkinter/ttk`.
 
-## Що зроблено під твій запит
+## Що покращено
 
-- ✅ **One-click OAuth**: натискаєш `Login with OpenAI` → браузер відкривається автоматично → токен повертається в app автоматично.
-- ✅ **Авто-список моделей**: кнопка `Refresh models` тягне **актуальний список з OpenAI `/v1/models`**, тому бачиш реально існуючі моделі, включно з Codex.
-- ✅ **Codex first**: у списку після refresh моделі з `codex` піднімаються на початок.
-- ✅ **Кращий UI/UX**: темна тема, статус-бар, clear output/tokens, блокування кнопок під час запитів.
-- ✅ **Fallback на API key** якщо OAuth не налаштований.
-- ✅ **Фікс Windows crash**: прибрано несумісні type-annotations (`| None`), тому EXE більше не падає з `unsupported operand type(s) for |`.
+- ✅ **One-click OAuth auto mode**: тиснеш `Login with OpenAI` — браузер відкривається автоматично, токен повертається в app.
+- ✅ **Без обов'язкового `OPENAI_OAUTH_CLIENT_ID`**: працює auto-mode, `client_id` додається тільки якщо заданий.
+- ✅ **Live model sync**: `Refresh models` підтягує актуальний список з `/v1/models`.
+- ✅ **Codex-first сортування**: моделі з `codex` показуються першими.
+- ✅ **Краща стабільність**: сумісні type hints для PyInstaller, без крашу `unsupported operand type(s) for |`.
+- ✅ **Кращий UX**: темна тема, статус-бар, блокування кнопок під час запитів, `Ctrl+Enter` для запуску.
 
 ## Швидкий старт (Windows)
 
 1. Встанови Python 3.10+.
 2. Запусти додаток:
    - `run_windows.bat`
-3. Натисни `Login with OpenAI`, залогінься в браузері.
-4. Натисни `Refresh models` (або після OAuth список оновиться автоматично).
-5. Пиши prompt і тисни `Run`.
-
-> `OPENAI_OAUTH_CLIENT_ID` тепер **не обов'язковий**: додаток працює в auto-mode і передає `client_id` лише якщо він заданий.
-
-## Моделі
-
-- При старті є fallback-перелік моделей для зручності.
-- Після авторизації тисни `Refresh models`, і додаток завантажить **всі доступні моделі саме для твого акаунта/токена**.
-- Можна вписувати будь-яку модель вручну в поле `Model`.
+3. Натисни `Login with OpenAI` і залогінься в браузері.
+4. Натисни `Refresh models` (або дочекайся авто-оновлення після OAuth).
+5. Введи prompt і натисни `Run` (або `Ctrl+Enter`).
 
 ## Налаштування через env (опціонально)
 
 - `OPENAI_API_KEY`
 - `OPENAI_OAUTH_TOKEN`
 - `OPENAI_MODEL`
-- `OPENAI_OAUTH_CLIENT_ID` (опціонально; додається автоматично, якщо задано)
+- `OPENAI_OAUTH_CLIENT_ID` (опціонально)
 - `OPENAI_OAUTH_AUTH_URL` (default: `https://auth.openai.com/oauth/authorize`)
 - `OPENAI_OAUTH_TOKEN_URL` (default: `https://auth.openai.com/oauth/token`)
 - `OPENAI_OAUTH_SCOPES` (default: `openid profile email`)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - ✅ **Codex first**: у списку після refresh моделі з `codex` піднімаються на початок.
 - ✅ **Кращий UI/UX**: темна тема, статус-бар, clear output/tokens, блокування кнопок під час запитів.
 - ✅ **Fallback на API key** якщо OAuth не налаштований.
+- ✅ **Фікс Windows crash**: прибрано несумісні type-annotations (`| None`), тому EXE більше не падає з `unsupported operand type(s) for |`.
 
 ## Швидкий старт (Windows)
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,22 @@
 
 ## Що покращено
 
-- ✅ **One-click OAuth auto mode**: тиснеш `Login with OpenAI` — браузер відкривається автоматично, токен повертається в app.
-- ✅ **Без обов'язкового `OPENAI_OAUTH_CLIENT_ID`**: працює auto-mode, `client_id` додається тільки якщо заданий.
+- ✅ **One-click OAuth**: тиснеш `Login with OpenAI` — браузер відкривається автоматично, токен повертається в app.
+- ✅ **Фікс auth-помилки `missing_required_parameter`**: додано поле `OAuth client id` + запит через діалог, якщо поле порожнє.
 - ✅ **Live model sync**: `Refresh models` підтягує актуальний список з `/v1/models`.
 - ✅ **Codex-first сортування**: моделі з `codex` показуються першими.
 - ✅ **Краща стабільність**: сумісні type hints для PyInstaller, без крашу `unsupported operand type(s) for |`.
-- ✅ **Кращий UX**: темна тема, статус-бар, блокування кнопок під час запитів, `Ctrl+Enter` для запуску.
+- ✅ **Кращий UX**: темна тема, статус-бар, блокування кнопок під час запитів, `Ctrl+Enter` для запуску, анімація завантаження (progress bar).
 
 ## Швидкий старт (Windows)
 
 1. Встанови Python 3.10+.
 2. Запусти додаток:
    - `run_windows.bat`
-3. Натисни `Login with OpenAI` і залогінься в браузері.
-4. Натисни `Refresh models` (або дочекайся авто-оновлення після OAuth).
-5. Введи prompt і натисни `Run` (або `Ctrl+Enter`).
+3. Вкажи `OAuth client id` (або додаток сам попросить його при вході).
+4. Натисни `Login with OpenAI` і залогінься в браузері.
+5. Натисни `Refresh models` (або дочекайся авто-оновлення після OAuth).
+6. Введи prompt і натисни `Run` (або `Ctrl+Enter`).
 
 ## Налаштування через env (опціонально)
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# codex_test
+# OpenAI Codex (for Windows)
+
+Сучасний desktop-клієнт OpenAI Codex для Windows на `tkinter/ttk`.
+
+## Що зроблено під твій запит
+
+- ✅ **One-click OAuth**: натискаєш `Login with OpenAI` → браузер відкривається автоматично → токен повертається в app автоматично.
+- ✅ **Авто-список моделей**: кнопка `Refresh models` тягне **актуальний список з OpenAI `/v1/models`**, тому бачиш реально існуючі моделі, включно з Codex.
+- ✅ **Codex first**: у списку після refresh моделі з `codex` піднімаються на початок.
+- ✅ **Кращий UI/UX**: темна тема, статус-бар, clear output/tokens, блокування кнопок під час запитів.
+- ✅ **Fallback на API key** якщо OAuth не налаштований.
+
+## Швидкий старт (Windows)
+
+1. Встанови Python 3.10+.
+2. Один раз задай OAuth client id:
+   - `setx OPENAI_OAUTH_CLIENT_ID "your_client_id_here"`
+3. Запусти додаток:
+   - `run_windows.bat`
+4. Натисни `Login with OpenAI`, залогінься в браузері.
+5. Натисни `Refresh models` (або після OAuth список оновиться автоматично).
+6. Пиши prompt і тисни `Run`.
+
+## Моделі
+
+- При старті є fallback-перелік моделей для зручності.
+- Після авторизації тисни `Refresh models`, і додаток завантажить **всі доступні моделі саме для твого акаунта/токена**.
+- Можна вписувати будь-яку модель вручну в поле `Model`.
+
+## Налаштування через env (опціонально)
+
+- `OPENAI_API_KEY`
+- `OPENAI_OAUTH_TOKEN`
+- `OPENAI_MODEL`
+- `OPENAI_OAUTH_AUTH_URL` (default: `https://auth.openai.com/oauth/authorize`)
+- `OPENAI_OAUTH_TOKEN_URL` (default: `https://auth.openai.com/oauth/token`)
+- `OPENAI_OAUTH_SCOPES` (default: `openid profile email`)
+- `OPENAI_OAUTH_REDIRECT_URI` (default: `http://127.0.0.1:8765/callback`)
+
+## Збірка EXE
+
+1. Встанови PyInstaller:
+   - `py -m pip install pyinstaller`
+2. Запусти:
+   - `build_windows.bat`
+3. Готовий файл:
+   - `dist\OpenAI-Codex-Windows.exe`
+
+## Файли
+
+- `app.py` — GUI застосунок.
+- `run_windows.bat` — запуск локально.
+- `build_windows.bat` — збірка `.exe`.

--- a/README.md
+++ b/README.md
@@ -2,31 +2,34 @@
 
 Сучасний desktop-клієнт OpenAI Codex для Windows на `tkinter/ttk`.
 
-## Що покращено
+## Головні покращення
 
-- ✅ **One-click OAuth**: тиснеш `Login with OpenAI` — браузер відкривається автоматично, токен повертається в app.
-- ✅ **Фікс auth-помилки `missing_required_parameter`**: додано поле `OAuth client id` + запит через діалог, якщо поле порожнє.
-- ✅ **Live model sync**: `Refresh models` підтягує актуальний список з `/v1/models`.
-- ✅ **Codex-first сортування**: моделі з `codex` показуються першими.
-- ✅ **Краща стабільність**: сумісні type hints для PyInstaller, без крашу `unsupported operand type(s) for |`.
-- ✅ **Кращий UX**: темна тема, статус-бар, блокування кнопок під час запитів, `Ctrl+Enter` для запуску, анімація завантаження (progress bar).
+- ✅ **Норм дизайн + вкладки**: `Assistant` і `Settings`.
+- ✅ **Реальний OAuth “1 кнопка і готово”**: натискаєш `Login with OpenAI (1 click)` — браузер відкривається, токен повертається в app.
+- ✅ **Auto fallback OAuth**: якщо endpoint вимагає `client_id`, app автоматично попросить його один раз і повторить логін.
+- ✅ **Live models**: `Refresh models` тягне актуальні моделі з `/v1/models`, Codex-першими.
+- ✅ **Кращий UX**: progress bar (анімація завантаження), блокування кнопок під час запитів, `Ctrl+Enter`.
 
 ## Швидкий старт (Windows)
 
 1. Встанови Python 3.10+.
-2. Запусти додаток:
+2. Запусти:
    - `run_windows.bat`
-3. Вкажи `OAuth client id` (або додаток сам попросить його при вході).
-4. Натисни `Login with OpenAI` і залогінься в браузері.
-5. Натисни `Refresh models` (або дочекайся авто-оновлення після OAuth).
-6. Введи prompt і натисни `Run` (або `Ctrl+Enter`).
+3. У вкладці `Assistant` натисни `Login with OpenAI (1 click)`.
+4. Якщо OAuth-сервер попросить `client_id`, app сам попросить ввести його і повторить процес.
+5. Натисни `Refresh models`, введи prompt, натисни `Run`.
+
+## Вкладки
+
+- **Assistant**: логін, токени, вибір моделі, prompt/response.
+- **Settings**: OAuth client id, auth/token URL, scopes, redirect URI.
 
 ## Налаштування через env (опціонально)
 
 - `OPENAI_API_KEY`
 - `OPENAI_OAUTH_TOKEN`
 - `OPENAI_MODEL`
-- `OPENAI_OAUTH_CLIENT_ID` (опціонально)
+- `OPENAI_OAUTH_CLIENT_ID`
 - `OPENAI_OAUTH_AUTH_URL` (default: `https://auth.openai.com/oauth/authorize`)
 - `OPENAI_OAUTH_TOKEN_URL` (default: `https://auth.openai.com/oauth/token`)
 - `OPENAI_OAUTH_SCOPES` (default: `openid profile email`)
@@ -38,7 +41,7 @@
    - `py -m pip install pyinstaller`
 2. Запусти:
    - `build_windows.bat`
-3. Готовий файл:
+3. EXE:
    - `dist\OpenAI-Codex-Windows.exe`
 
 ## Файли

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from tkinter import messagebox, scrolledtext, ttk
 from urllib import error, parse, request
+from typing import Any, Dict, List, Optional, Tuple
 
 API_BASE = "https://api.openai.com/v1"
 RESPONSES_URL = f"{API_BASE}/responses"
@@ -304,7 +305,7 @@ class CodexWindowsApp:
             self._set_busy(False)
 
 
-def _http_json(method: str, url: str, bearer: str, body: dict | None = None) -> dict:
+def _http_json(method: str, url: str, bearer: str, body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     data = None if body is None else json.dumps(body).encode("utf-8")
     req = request.Request(url, data=data, method=method)
     req.add_header("Authorization", f"Bearer {bearer}")
@@ -322,7 +323,7 @@ def _http_json(method: str, url: str, bearer: str, body: dict | None = None) -> 
     return json.loads(raw)
 
 
-def _fetch_models(bearer: str) -> list[str]:
+def _fetch_models(bearer: str) -> List[str]:
     parsed = _http_json("GET", MODELS_URL, bearer)
     data = parsed.get("data", [])
     model_ids = [item.get("id", "") for item in data if isinstance(item, dict)]
@@ -356,7 +357,7 @@ def _create_code_challenge(verifier: str) -> str:
 
 def _finish_oauth_flow(
     token_url: str,
-    client_id: str | None,
+    client_id: Optional[str],
     redirect_uri: str,
     expected_state: str,
     code_verifier: str,
@@ -376,7 +377,7 @@ def _finish_oauth_flow(
     return OAuthResult(access_token=token, state=returned_state)
 
 
-def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> tuple[str, str]:
+def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> Tuple[str, str]:
     parsed_redirect = parse.urlparse(redirect_uri)
     result = {"code": None, "state": None}
 
@@ -412,7 +413,7 @@ def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> tuple[str, str
     return str(result["code"]), str(result["state"] or "")
 
 
-def _exchange_oauth_token(token_url: str, client_id: str | None, code: str, redirect_uri: str, code_verifier: str) -> str:
+def _exchange_oauth_token(token_url: str, client_id: Optional[str], code: str, redirect_uri: str, code_verifier: str) -> str:
     payload = {
         "grant_type": "authorization_code",
         "code": code,

--- a/app.py
+++ b/app.py
@@ -62,15 +62,15 @@ class CodexWindowsApp:
         self.cfg = load_config()
 
         self.root.title("OpenAI Codex for Windows")
-        self.root.geometry("1140x780")
-        self.root.minsize(900, 640)
+        self.root.geometry("1160x800")
+        self.root.minsize(920, 680)
         self.root.configure(bg="#0f172a")
 
         self.api_key = tk.StringVar(value=os.getenv("OPENAI_API_KEY", ""))
         self.oauth_token = tk.StringVar(value=os.getenv("OPENAI_OAUTH_TOKEN", ""))
+        self.oauth_client_id = tk.StringVar(value=self.cfg.oauth_client_id)
         self.model = tk.StringVar(value=os.getenv("OPENAI_MODEL", DEFAULT_MODEL))
         self.status = tk.StringVar(value="Ready")
-        self.oauth_client_id = tk.StringVar(value=self.cfg.oauth_client_id)
 
         self._configure_theme()
         self._build_ui()
@@ -94,29 +94,43 @@ class CodexWindowsApp:
         header = ttk.Frame(outer, style="App.TFrame")
         header.pack(fill=tk.X, pady=(0, 10))
         ttk.Label(header, text="OpenAI Codex Desktop", style="Header.TLabel").pack(side=tk.LEFT)
-        ttk.Label(header, text="Windows • OAuth auto-login • Live model sync", style="Sub.TLabel").pack(side=tk.RIGHT)
+        ttk.Label(header, text="Windows • Real OAuth • Tabs UI", style="Sub.TLabel").pack(side=tk.RIGHT)
 
-        cred = ttk.LabelFrame(outer, text="Authorization", padding=10)
-        cred.pack(fill=tk.X, pady=(0, 10))
+        notebook = ttk.Notebook(outer)
+        notebook.pack(fill=tk.BOTH, expand=True)
 
-        ttk.Label(cred, text="OAuth access token", style="Sub.TLabel").grid(row=0, column=0, sticky="w")
-        ttk.Entry(cred, textvariable=self.oauth_token, show="*", width=70).grid(row=0, column=1, sticky="ew", padx=8)
-        self.oauth_btn = ttk.Button(cred, text="Login with OpenAI", style="Accent.TButton", command=self.start_oauth)
+        assistant_tab = ttk.Frame(notebook, padding=10)
+        settings_tab = ttk.Frame(notebook, padding=10)
+        notebook.add(assistant_tab, text="Assistant")
+        notebook.add(settings_tab, text="Settings")
+
+        self._build_assistant_tab(assistant_tab)
+        self._build_settings_tab(settings_tab)
+
+        self.progress = ttk.Progressbar(outer, mode="indeterminate")
+        self.progress.pack(fill=tk.X, pady=(10, 0))
+        ttk.Label(outer, textvariable=self.status, style="Sub.TLabel").pack(fill=tk.X, pady=(4, 0))
+
+    def _build_assistant_tab(self, parent: ttk.Frame) -> None:
+        auth = ttk.LabelFrame(parent, text="Quick auth", padding=10)
+        auth.pack(fill=tk.X, pady=(0, 10))
+
+        ttk.Label(auth, text="OAuth token", style="Sub.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Entry(auth, textvariable=self.oauth_token, show="*", width=70).grid(row=0, column=1, sticky="ew", padx=8)
+
+        self.oauth_btn = ttk.Button(auth, text="Login with OpenAI (1 click)", style="Accent.TButton", command=self.start_oauth)
         self.oauth_btn.grid(row=0, column=2, sticky="w")
 
-        ttk.Label(cred, text="OAuth client id", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
-        ttk.Entry(cred, textvariable=self.oauth_client_id, width=70).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
-        ttk.Label(cred, text="(required by many OAuth setups)", style="Sub.TLabel").grid(row=1, column=2, sticky="w", pady=(8, 0))
+        ttk.Label(auth, text="API key (fallback)", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(auth, textvariable=self.api_key, show="*", width=70).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Button(auth, text="Clear tokens", command=self.clear_tokens).grid(row=1, column=2, sticky="w", pady=(8, 0))
 
-        ttk.Label(cred, text="API key (fallback)", style="Sub.TLabel").grid(row=2, column=0, sticky="w", pady=(8, 0))
-        ttk.Entry(cred, textvariable=self.api_key, show="*", width=70).grid(row=2, column=1, sticky="ew", padx=8, pady=(8, 0))
-        ttk.Button(cred, text="Clear tokens", command=self.clear_tokens).grid(row=2, column=2, sticky="w", pady=(8, 0))
-        cred.columnconfigure(1, weight=1)
+        auth.columnconfigure(1, weight=1)
 
-        main = ttk.LabelFrame(outer, text="Model + Prompt", padding=10)
-        main.pack(fill=tk.BOTH, expand=True)
+        work = ttk.LabelFrame(parent, text="Prompt", padding=10)
+        work.pack(fill=tk.BOTH, expand=True)
 
-        controls = ttk.Frame(main)
+        controls = ttk.Frame(work)
         controls.pack(fill=tk.X, pady=(0, 8))
 
         ttk.Label(controls, text="Model", style="Sub.TLabel").pack(side=tk.LEFT)
@@ -127,11 +141,11 @@ class CodexWindowsApp:
 
         self.run_btn = ttk.Button(controls, text="Run", style="Accent.TButton", command=self.ask_model)
         self.run_btn.pack(side=tk.RIGHT)
-        ttk.Button(controls, text="Clear Output", command=self.clear_output).pack(side=tk.RIGHT, padx=6)
+        ttk.Button(controls, text="Clear output", command=self.clear_output).pack(side=tk.RIGHT, padx=6)
 
-        ttk.Label(main, text="Prompt (Ctrl+Enter to run)", style="Sub.TLabel").pack(anchor="w")
+        ttk.Label(work, text="Prompt (Ctrl+Enter to run)", style="Sub.TLabel").pack(anchor="w")
         self.prompt = scrolledtext.ScrolledText(
-            main,
+            work,
             height=10,
             wrap=tk.WORD,
             bg="#0b1220",
@@ -142,14 +156,10 @@ class CodexWindowsApp:
             pady=10,
         )
         self.prompt.pack(fill=tk.BOTH, expand=False)
-        self.prompt.insert(
-            "1.0",
-            "Напиши короткий план дій та приклад коду для задачі, яку я опишу нижче...",
-        )
 
-        ttk.Label(main, text="Response / Logs", style="Sub.TLabel").pack(anchor="w", pady=(8, 0))
+        ttk.Label(work, text="Response / Logs", style="Sub.TLabel").pack(anchor="w", pady=(8, 0))
         self.output = scrolledtext.ScrolledText(
-            main,
+            work,
             wrap=tk.WORD,
             state=tk.DISABLED,
             bg="#020617",
@@ -161,15 +171,40 @@ class CodexWindowsApp:
         )
         self.output.pack(fill=tk.BOTH, expand=True)
 
-        ttk.Label(
-            outer,
-            text="Tip: після OAuth натисни Refresh models, щоб отримати повний актуальний список /v1/models.",
-            style="Sub.TLabel",
-        ).pack(fill=tk.X, pady=(8, 0))
+    def _build_settings_tab(self, parent: ttk.Frame) -> None:
+        oauth = ttk.LabelFrame(parent, text="OAuth settings", padding=10)
+        oauth.pack(fill=tk.X, pady=(0, 10))
 
-        self.progress = ttk.Progressbar(outer, mode="indeterminate")
-        self.progress.pack(fill=tk.X, pady=(4, 0))
-        ttk.Label(outer, textvariable=self.status, style="Sub.TLabel").pack(fill=tk.X, pady=(4, 0))
+        ttk.Label(oauth, text="OAuth client id", style="Sub.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Entry(oauth, textvariable=self.oauth_client_id, width=68).grid(row=0, column=1, sticky="ew", padx=8)
+
+        self.auth_url = tk.StringVar(value=self.cfg.oauth_auth_url)
+        self.token_url = tk.StringVar(value=self.cfg.oauth_token_url)
+        self.scopes = tk.StringVar(value=self.cfg.oauth_scopes)
+        self.redirect_uri = tk.StringVar(value=self.cfg.oauth_redirect_uri)
+
+        ttk.Label(oauth, text="Auth URL", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(oauth, textvariable=self.auth_url, width=68).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Label(oauth, text="Token URL", style="Sub.TLabel").grid(row=2, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(oauth, textvariable=self.token_url, width=68).grid(row=2, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Label(oauth, text="Scopes", style="Sub.TLabel").grid(row=3, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(oauth, textvariable=self.scopes, width=68).grid(row=3, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Label(oauth, text="Redirect URI", style="Sub.TLabel").grid(row=4, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(oauth, textvariable=self.redirect_uri, width=68).grid(row=4, column=1, sticky="ew", padx=8, pady=(8, 0))
+        oauth.columnconfigure(1, weight=1)
+
+        tip = ttk.LabelFrame(parent, text="How one-click works", padding=10)
+        tip.pack(fill=tk.X)
+        ttk.Label(
+            tip,
+            text=(
+                "Натискаєш кнопку Login -> app відкриває браузер -> ловить callback локально -> "
+                "міняє code на access_token -> вставляє токен автоматично."
+            ),
+            style="Sub.TLabel",
+            wraplength=960,
+            justify=tk.LEFT,
+        ).pack(anchor="w")
 
     def _bind_shortcuts(self) -> None:
         self.root.bind("<Control-Return>", lambda _e: self.ask_model())
@@ -240,8 +275,6 @@ class CodexWindowsApp:
             models = _fetch_models(bearer)
             ordered = _codex_first(models)
             self.root.after(0, lambda: self._set_model_options(ordered))
-            if ordered and not self.model.get().strip():
-                self.root.after(0, lambda: self.model.set(ordered[0]))
             self._log(f"[Models] Loaded {len(ordered)} models from OpenAI.")
             self._set_status("Models refreshed")
         except Exception as exc:
@@ -282,19 +315,6 @@ class CodexWindowsApp:
             self._set_busy(False)
 
     def start_oauth(self) -> None:
-        client_id = self.oauth_client_id.get().strip()
-        if not client_id:
-            client_id = simpledialog.askstring(
-                "OAuth Client ID",
-                "Введи OPENAI OAuth Client ID (потрібно для авторизації):",
-                parent=self.root,
-            ) or ""
-            client_id = client_id.strip()
-            if not client_id:
-                messagebox.showerror("Missing OAuth client id", "OAuth client id required by auth server.")
-                return
-            self.oauth_client_id.set(client_id)
-
         self._set_busy(True)
         self.root.after(0, lambda: self.oauth_btn.config(text="Waiting OAuth..."))
         self._set_status("OAuth login started...")
@@ -306,33 +326,62 @@ class CodexWindowsApp:
             challenge = _create_code_challenge(verifier)
             state = secrets.token_urlsafe(24)
 
+            client_id = self.oauth_client_id.get().strip()
             auth_params = {
                 "response_type": "code",
-                "redirect_uri": self.cfg.oauth_redirect_uri,
-                "scope": self.cfg.oauth_scopes,
+                "redirect_uri": self.redirect_uri.get().strip(),
+                "scope": self.scopes.get().strip() or "openid profile email",
                 "state": state,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
             }
-            client_id = self.oauth_client_id.get().strip()
             if client_id:
                 auth_params["client_id"] = client_id
 
-            launch_url = f"{self.cfg.oauth_auth_url}?{parse.urlencode(auth_params)}"
+            launch_url = f"{self.auth_url.get().strip()}?{parse.urlencode(auth_params)}"
             self._log("[OAuth] Opening browser for OpenAI sign-in...")
             opened = webbrowser.open(launch_url)
             if not opened:
                 self._log("[OAuth] Could not open browser automatically. Open this URL manually:")
                 self._log(launch_url)
 
-            oauth = _finish_oauth_flow(
-                token_url=self.cfg.oauth_token_url,
-                client_id=client_id or None,
-                redirect_uri=self.cfg.oauth_redirect_uri,
-                expected_state=state,
-                code_verifier=verifier,
-                timeout_s=240,
-            )
+            try:
+                oauth = _finish_oauth_flow(
+                    token_url=self.token_url.get().strip(),
+                    client_id=client_id or None,
+                    redirect_uri=self.redirect_uri.get().strip(),
+                    expected_state=state,
+                    code_verifier=verifier,
+                    timeout_s=240,
+                )
+            except RuntimeError as first_error:
+                # one-click fallback: if server requires client_id and it is missing, ask once and retry.
+                if "missing_required_parameter" in str(first_error) and not client_id:
+                    cid = self._ask_client_id_blocking()
+                    if not cid:
+                        raise
+                    self.root.after(0, lambda: self.oauth_client_id.set(cid))
+                    self._log("[OAuth] Retrying with provided client_id...")
+                    verifier2 = _create_code_verifier()
+                    challenge2 = _create_code_challenge(verifier2)
+                    state2 = secrets.token_urlsafe(24)
+                    params2 = dict(auth_params)
+                    params2["client_id"] = cid
+                    params2["state"] = state2
+                    params2["code_challenge"] = challenge2
+                    launch2 = f"{self.auth_url.get().strip()}?{parse.urlencode(params2)}"
+                    webbrowser.open(launch2)
+                    oauth = _finish_oauth_flow(
+                        token_url=self.token_url.get().strip(),
+                        client_id=cid,
+                        redirect_uri=self.redirect_uri.get().strip(),
+                        expected_state=state2,
+                        code_verifier=verifier2,
+                        timeout_s=240,
+                    )
+                else:
+                    raise
+
             self.root.after(0, lambda: self.oauth_token.set(oauth.access_token))
             self._log("[OAuth] Login done. Access token inserted automatically.")
 
@@ -346,11 +395,32 @@ class CodexWindowsApp:
             msg = str(exc)
             self._log(f"[OAuth][ERROR] {msg}")
             if "missing_required_parameter" in msg:
-                self._log("[OAuth] Схоже, потрібен client_id. Вкажи його у полі OAuth client id і спробуй ще раз.")
+                self._log("[OAuth] Цей OAuth endpoint вимагає client_id. Вкажи його у вкладці Settings.")
             self._set_status("OAuth login failed")
         finally:
-            self.root.after(0, lambda: self.oauth_btn.config(text="Login with OpenAI"))
+            self.root.after(0, lambda: self.oauth_btn.config(text="Login with OpenAI (1 click)"))
             self._set_busy(False)
+
+    def _ask_client_id_blocking(self) -> str:
+        result = {"value": ""}
+
+        def ask() -> None:
+            val = simpledialog.askstring(
+                "OAuth Client ID",
+                "OAuth server requires client_id. Enter OPENAI OAuth Client ID:",
+                parent=self.root,
+            )
+            result["value"] = (val or "").strip()
+
+        event = threading.Event()
+
+        def wrapped() -> None:
+            ask()
+            event.set()
+
+        self.root.after(0, wrapped)
+        event.wait(timeout=300)
+        return result["value"]
 
 
 def _codex_first(models: List[str]) -> List[str]:

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ MODEL_FALLBACK = [
     "o4-mini",
 ]
 
-# OAuth defaults. Client ID must be provided via env.
+# OAuth defaults. Client ID optional (auto mode).
 OAUTH_CLIENT_ID = os.getenv("OPENAI_OAUTH_CLIENT_ID", "").strip()
 OAUTH_AUTH_URL = os.getenv("OPENAI_OAUTH_AUTH_URL", "https://auth.openai.com/oauth/authorize").strip()
 OAUTH_TOKEN_URL = os.getenv("OPENAI_OAUTH_TOKEN_URL", "https://auth.openai.com/oauth/token").strip()
@@ -254,13 +254,6 @@ class CodexWindowsApp:
             self._set_busy(False)
 
     def start_oauth(self) -> None:
-        if not OAUTH_CLIENT_ID:
-            messagebox.showerror(
-                "Missing OAuth client",
-                "Set OPENAI_OAUTH_CLIENT_ID in Windows environment variables and restart app.",
-            )
-            return
-
         self._set_busy(True)
         self.root.after(0, lambda: self.oauth_btn.config(text="Waiting OAuth..."))
         self._set_status("OAuth login started...")
@@ -273,20 +266,21 @@ class CodexWindowsApp:
             state = secrets.token_urlsafe(24)
             auth_params = {
                 "response_type": "code",
-                "client_id": OAUTH_CLIENT_ID,
                 "redirect_uri": OAUTH_REDIRECT_URI,
                 "scope": OAUTH_SCOPES,
                 "state": state,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
             }
+            if OAUTH_CLIENT_ID:
+                auth_params["client_id"] = OAUTH_CLIENT_ID
             launch_url = f"{OAUTH_AUTH_URL}?{parse.urlencode(auth_params)}"
             self._log("[OAuth] Opening browser for OpenAI sign-in...")
             webbrowser.open(launch_url)
 
             oauth = _finish_oauth_flow(
                 token_url=OAUTH_TOKEN_URL,
-                client_id=OAUTH_CLIENT_ID,
+                client_id=OAUTH_CLIENT_ID or None,
                 redirect_uri=OAUTH_REDIRECT_URI,
                 expected_state=state,
                 code_verifier=verifier,
@@ -362,7 +356,7 @@ def _create_code_challenge(verifier: str) -> str:
 
 def _finish_oauth_flow(
     token_url: str,
-    client_id: str,
+    client_id: str | None,
     redirect_uri: str,
     expected_state: str,
     code_verifier: str,
@@ -418,14 +412,15 @@ def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> tuple[str, str
     return str(result["code"]), str(result["state"] or "")
 
 
-def _exchange_oauth_token(token_url: str, client_id: str, code: str, redirect_uri: str, code_verifier: str) -> str:
+def _exchange_oauth_token(token_url: str, client_id: str | None, code: str, redirect_uri: str, code_verifier: str) -> str:
     payload = {
         "grant_type": "authorization_code",
-        "client_id": client_id,
         "code": code,
         "redirect_uri": redirect_uri,
         "code_verifier": code_verifier,
     }
+    if client_id:
+        payload["client_id"] = client_id
     req = request.Request(token_url, data=parse.urlencode(payload).encode("utf-8"), method="POST")
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
 

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import tkinter as tk
 import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from tkinter import messagebox, scrolledtext, ttk
+from tkinter import messagebox, scrolledtext, simpledialog, ttk
 from typing import Any, Dict, List, Optional, Tuple
 from urllib import error, parse, request
 
@@ -70,6 +70,7 @@ class CodexWindowsApp:
         self.oauth_token = tk.StringVar(value=os.getenv("OPENAI_OAUTH_TOKEN", ""))
         self.model = tk.StringVar(value=os.getenv("OPENAI_MODEL", DEFAULT_MODEL))
         self.status = tk.StringVar(value="Ready")
+        self.oauth_client_id = tk.StringVar(value=self.cfg.oauth_client_id)
 
         self._configure_theme()
         self._build_ui()
@@ -103,9 +104,13 @@ class CodexWindowsApp:
         self.oauth_btn = ttk.Button(cred, text="Login with OpenAI", style="Accent.TButton", command=self.start_oauth)
         self.oauth_btn.grid(row=0, column=2, sticky="w")
 
-        ttk.Label(cred, text="API key (fallback)", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
-        ttk.Entry(cred, textvariable=self.api_key, show="*", width=70).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
-        ttk.Button(cred, text="Clear tokens", command=self.clear_tokens).grid(row=1, column=2, sticky="w", pady=(8, 0))
+        ttk.Label(cred, text="OAuth client id", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(cred, textvariable=self.oauth_client_id, width=70).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Label(cred, text="(required by many OAuth setups)", style="Sub.TLabel").grid(row=1, column=2, sticky="w", pady=(8, 0))
+
+        ttk.Label(cred, text="API key (fallback)", style="Sub.TLabel").grid(row=2, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(cred, textvariable=self.api_key, show="*", width=70).grid(row=2, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Button(cred, text="Clear tokens", command=self.clear_tokens).grid(row=2, column=2, sticky="w", pady=(8, 0))
         cred.columnconfigure(1, weight=1)
 
         main = ttk.LabelFrame(outer, text="Model + Prompt", padding=10)
@@ -162,6 +167,8 @@ class CodexWindowsApp:
             style="Sub.TLabel",
         ).pack(fill=tk.X, pady=(8, 0))
 
+        self.progress = ttk.Progressbar(outer, mode="indeterminate")
+        self.progress.pack(fill=tk.X, pady=(4, 0))
         ttk.Label(outer, textvariable=self.status, style="Sub.TLabel").pack(fill=tk.X, pady=(4, 0))
 
     def _bind_shortcuts(self) -> None:
@@ -184,6 +191,10 @@ class CodexWindowsApp:
         self.root.after(0, lambda: self.run_btn.config(state=state))
         self.root.after(0, lambda: self.oauth_btn.config(state=state))
         self.root.after(0, lambda: self.refresh_models_btn.config(state=state))
+        if busy:
+            self.root.after(0, lambda: self.progress.start(10))
+        else:
+            self.root.after(0, self.progress.stop)
 
     def clear_tokens(self) -> None:
         self.oauth_token.set("")
@@ -271,6 +282,19 @@ class CodexWindowsApp:
             self._set_busy(False)
 
     def start_oauth(self) -> None:
+        client_id = self.oauth_client_id.get().strip()
+        if not client_id:
+            client_id = simpledialog.askstring(
+                "OAuth Client ID",
+                "Введи OPENAI OAuth Client ID (потрібно для авторизації):",
+                parent=self.root,
+            ) or ""
+            client_id = client_id.strip()
+            if not client_id:
+                messagebox.showerror("Missing OAuth client id", "OAuth client id required by auth server.")
+                return
+            self.oauth_client_id.set(client_id)
+
         self._set_busy(True)
         self.root.after(0, lambda: self.oauth_btn.config(text="Waiting OAuth..."))
         self._set_status("OAuth login started...")
@@ -290,8 +314,9 @@ class CodexWindowsApp:
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
             }
-            if self.cfg.oauth_client_id:
-                auth_params["client_id"] = self.cfg.oauth_client_id
+            client_id = self.oauth_client_id.get().strip()
+            if client_id:
+                auth_params["client_id"] = client_id
 
             launch_url = f"{self.cfg.oauth_auth_url}?{parse.urlencode(auth_params)}"
             self._log("[OAuth] Opening browser for OpenAI sign-in...")
@@ -302,7 +327,7 @@ class CodexWindowsApp:
 
             oauth = _finish_oauth_flow(
                 token_url=self.cfg.oauth_token_url,
-                client_id=self.cfg.oauth_client_id or None,
+                client_id=client_id or None,
                 redirect_uri=self.cfg.oauth_redirect_uri,
                 expected_state=state,
                 code_verifier=verifier,
@@ -318,7 +343,10 @@ class CodexWindowsApp:
                 self.root.after(0, lambda: self.model.set(ordered[0]))
             self._set_status("OAuth login successful")
         except Exception as exc:
-            self._log(f"[OAuth][ERROR] {exc}")
+            msg = str(exc)
+            self._log(f"[OAuth][ERROR] {msg}")
+            if "missing_required_parameter" in msg:
+                self._log("[OAuth] Схоже, потрібен client_id. Вкажи його у полі OAuth client id і спробуй ще раз.")
             self._set_status("OAuth login failed")
         finally:
             self.root.after(0, lambda: self.oauth_btn.config(text="Login with OpenAI"))

--- a/app.py
+++ b/app.py
@@ -10,8 +10,8 @@ import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from tkinter import messagebox, scrolledtext, ttk
-from urllib import error, parse, request
 from typing import Any, Dict, List, Optional, Tuple
+from urllib import error, parse, request
 
 API_BASE = "https://api.openai.com/v1"
 RESPONSES_URL = f"{API_BASE}/responses"
@@ -30,12 +30,14 @@ MODEL_FALLBACK = [
     "o4-mini",
 ]
 
-# OAuth defaults. Client ID optional (auto mode).
-OAUTH_CLIENT_ID = os.getenv("OPENAI_OAUTH_CLIENT_ID", "").strip()
-OAUTH_AUTH_URL = os.getenv("OPENAI_OAUTH_AUTH_URL", "https://auth.openai.com/oauth/authorize").strip()
-OAUTH_TOKEN_URL = os.getenv("OPENAI_OAUTH_TOKEN_URL", "https://auth.openai.com/oauth/token").strip()
-OAUTH_SCOPES = os.getenv("OPENAI_OAUTH_SCOPES", "openid profile email").strip()
-OAUTH_REDIRECT_URI = os.getenv("OPENAI_OAUTH_REDIRECT_URI", "http://127.0.0.1:8765/callback").strip()
+
+@dataclass
+class AppConfig:
+    oauth_client_id: str
+    oauth_auth_url: str
+    oauth_token_url: str
+    oauth_scopes: str
+    oauth_redirect_uri: str
 
 
 @dataclass
@@ -44,12 +46,24 @@ class OAuthResult:
     state: str
 
 
+def load_config() -> AppConfig:
+    return AppConfig(
+        oauth_client_id=os.getenv("OPENAI_OAUTH_CLIENT_ID", "").strip(),
+        oauth_auth_url=os.getenv("OPENAI_OAUTH_AUTH_URL", "https://auth.openai.com/oauth/authorize").strip(),
+        oauth_token_url=os.getenv("OPENAI_OAUTH_TOKEN_URL", "https://auth.openai.com/oauth/token").strip(),
+        oauth_scopes=os.getenv("OPENAI_OAUTH_SCOPES", "openid profile email").strip(),
+        oauth_redirect_uri=os.getenv("OPENAI_OAUTH_REDIRECT_URI", "http://127.0.0.1:8765/callback").strip(),
+    )
+
+
 class CodexWindowsApp:
     def __init__(self, root: tk.Tk) -> None:
         self.root = root
+        self.cfg = load_config()
+
         self.root.title("OpenAI Codex for Windows")
-        self.root.geometry("1120x780")
-        self.root.minsize(860, 620)
+        self.root.geometry("1140x780")
+        self.root.minsize(900, 640)
         self.root.configure(bg="#0f172a")
 
         self.api_key = tk.StringVar(value=os.getenv("OPENAI_API_KEY", ""))
@@ -59,6 +73,7 @@ class CodexWindowsApp:
 
         self._configure_theme()
         self._build_ui()
+        self._bind_shortcuts()
         self._set_model_options(MODEL_FALLBACK)
 
     def _configure_theme(self) -> None:
@@ -66,99 +81,91 @@ class CodexWindowsApp:
         if "clam" in style.theme_names():
             style.theme_use("clam")
 
-        style.configure("Card.TFrame", background="#111827")
-        style.configure("Title.TLabel", background="#111827", foreground="#e5e7eb", font=("Segoe UI", 12, "bold"))
-        style.configure("Label.TLabel", background="#111827", foreground="#cbd5e1", font=("Segoe UI", 10))
+        style.configure("App.TFrame", background="#111827")
+        style.configure("Header.TLabel", background="#111827", foreground="#e5e7eb", font=("Segoe UI", 13, "bold"))
+        style.configure("Sub.TLabel", background="#111827", foreground="#9ca3af", font=("Segoe UI", 10))
         style.configure("Accent.TButton", font=("Segoe UI", 10, "bold"))
 
     def _build_ui(self) -> None:
-        outer = ttk.Frame(self.root, style="Card.TFrame", padding=14)
+        outer = ttk.Frame(self.root, style="App.TFrame", padding=14)
         outer.pack(fill=tk.BOTH, expand=True)
 
-        header = ttk.Frame(outer, style="Card.TFrame")
+        header = ttk.Frame(outer, style="App.TFrame")
         header.pack(fill=tk.X, pady=(0, 10))
-        ttk.Label(header, text="OpenAI Codex Desktop", style="Title.TLabel").pack(side=tk.LEFT)
-        ttk.Label(header, text="Windows • One-click OAuth • Auto-model sync", style="Label.TLabel").pack(side=tk.RIGHT)
+        ttk.Label(header, text="OpenAI Codex Desktop", style="Header.TLabel").pack(side=tk.LEFT)
+        ttk.Label(header, text="Windows • OAuth auto-login • Live model sync", style="Sub.TLabel").pack(side=tk.RIGHT)
 
         cred = ttk.LabelFrame(outer, text="Authorization", padding=10)
         cred.pack(fill=tk.X, pady=(0, 10))
 
-        ttk.Label(cred, text="OAuth Access Token", style="Label.TLabel").grid(row=0, column=0, sticky="w")
-        ttk.Entry(cred, textvariable=self.oauth_token, show="*", width=68).grid(row=0, column=1, sticky="ew", padx=8)
+        ttk.Label(cred, text="OAuth access token", style="Sub.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Entry(cred, textvariable=self.oauth_token, show="*", width=70).grid(row=0, column=1, sticky="ew", padx=8)
         self.oauth_btn = ttk.Button(cred, text="Login with OpenAI", style="Accent.TButton", command=self.start_oauth)
         self.oauth_btn.grid(row=0, column=2, sticky="w")
 
-        ttk.Label(cred, text="API Key (fallback)", style="Label.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
-        ttk.Entry(cred, textvariable=self.api_key, show="*", width=68).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Label(cred, text="API key (fallback)", style="Sub.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(cred, textvariable=self.api_key, show="*", width=70).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
         ttk.Button(cred, text="Clear tokens", command=self.clear_tokens).grid(row=1, column=2, sticky="w", pady=(8, 0))
         cred.columnconfigure(1, weight=1)
 
-        config = ttk.LabelFrame(outer, text="Model + Prompt", padding=10)
-        config.pack(fill=tk.BOTH, expand=True)
+        main = ttk.LabelFrame(outer, text="Model + Prompt", padding=10)
+        main.pack(fill=tk.BOTH, expand=True)
 
-        top_row = ttk.Frame(config)
-        top_row.pack(fill=tk.X, pady=(0, 8))
+        controls = ttk.Frame(main)
+        controls.pack(fill=tk.X, pady=(0, 8))
 
-        ttk.Label(top_row, text="Model", style="Label.TLabel").pack(side=tk.LEFT)
-        self.model_box = ttk.Combobox(top_row, textvariable=self.model, width=28)
+        ttk.Label(controls, text="Model", style="Sub.TLabel").pack(side=tk.LEFT)
+        self.model_box = ttk.Combobox(controls, textvariable=self.model, width=30)
         self.model_box.pack(side=tk.LEFT, padx=(8, 10))
-        self.refresh_models_btn = ttk.Button(top_row, text="Refresh models", command=self.refresh_models)
+        self.refresh_models_btn = ttk.Button(controls, text="Refresh models", command=self.refresh_models)
         self.refresh_models_btn.pack(side=tk.LEFT)
 
-        self.run_btn = ttk.Button(top_row, text="Run", style="Accent.TButton", command=self.ask_model)
+        self.run_btn = ttk.Button(controls, text="Run", style="Accent.TButton", command=self.ask_model)
         self.run_btn.pack(side=tk.RIGHT)
-        ttk.Button(top_row, text="Clear Output", command=self.clear_output).pack(side=tk.RIGHT, padx=6)
+        ttk.Button(controls, text="Clear Output", command=self.clear_output).pack(side=tk.RIGHT, padx=6)
 
-        ttk.Label(config, text="Prompt", style="Label.TLabel").pack(anchor="w")
+        ttk.Label(main, text="Prompt (Ctrl+Enter to run)", style="Sub.TLabel").pack(anchor="w")
         self.prompt = scrolledtext.ScrolledText(
-            config,
+            main,
             height=10,
             wrap=tk.WORD,
             bg="#0b1220",
             fg="#d1d5db",
             insertbackground="#f8fafc",
             relief=tk.FLAT,
-            padx=8,
-            pady=8,
+            padx=10,
+            pady=10,
         )
         self.prompt.pack(fill=tk.BOTH, expand=False)
+        self.prompt.insert(
+            "1.0",
+            "Напиши короткий план дій та приклад коду для задачі, яку я опишу нижче...",
+        )
 
-        ttk.Label(config, text="Response / Logs", style="Label.TLabel").pack(anchor="w", pady=(8, 0))
+        ttk.Label(main, text="Response / Logs", style="Sub.TLabel").pack(anchor="w", pady=(8, 0))
         self.output = scrolledtext.ScrolledText(
-            config,
+            main,
             wrap=tk.WORD,
             state=tk.DISABLED,
             bg="#020617",
             fg="#dbeafe",
             insertbackground="#f8fafc",
             relief=tk.FLAT,
-            padx=8,
-            pady=8,
+            padx=10,
+            pady=10,
         )
         self.output.pack(fill=tk.BOTH, expand=True)
 
         ttk.Label(
             outer,
-            text=(
-                "Tip: натисни Refresh models після OAuth — список підтягнеться автоматично з /v1/models "
-                "і покаже актуальні Codex-моделі."
-            ),
-            style="Label.TLabel",
+            text="Tip: після OAuth натисни Refresh models, щоб отримати повний актуальний список /v1/models.",
+            style="Sub.TLabel",
         ).pack(fill=tk.X, pady=(8, 0))
 
-        footer = ttk.Label(outer, textvariable=self.status, style="Label.TLabel")
-        footer.pack(fill=tk.X, pady=(6, 0))
+        ttk.Label(outer, textvariable=self.status, style="Sub.TLabel").pack(fill=tk.X, pady=(4, 0))
 
-    def clear_tokens(self) -> None:
-        self.oauth_token.set("")
-        self.api_key.set("")
-        self._set_status("Tokens cleared")
-
-    def clear_output(self) -> None:
-        self.output.config(state=tk.NORMAL)
-        self.output.delete("1.0", tk.END)
-        self.output.config(state=tk.DISABLED)
-        self._set_status("Output cleared")
+    def _bind_shortcuts(self) -> None:
+        self.root.bind("<Control-Return>", lambda _e: self.ask_model())
 
     def _set_status(self, text: str) -> None:
         self.root.after(0, lambda: self.status.set(text))
@@ -175,8 +182,19 @@ class CodexWindowsApp:
     def _set_busy(self, busy: bool) -> None:
         state = tk.DISABLED if busy else tk.NORMAL
         self.root.after(0, lambda: self.run_btn.config(state=state))
-        self.root.after(0, lambda: self.oauth_btn.config(state=state if not busy else tk.DISABLED))
+        self.root.after(0, lambda: self.oauth_btn.config(state=state))
         self.root.after(0, lambda: self.refresh_models_btn.config(state=state))
+
+    def clear_tokens(self) -> None:
+        self.oauth_token.set("")
+        self.api_key.set("")
+        self._set_status("Tokens cleared")
+
+    def clear_output(self) -> None:
+        self.output.config(state=tk.NORMAL)
+        self.output.delete("1.0", tk.END)
+        self.output.config(state=tk.DISABLED)
+        self._set_status("Output cleared")
 
     def _resolve_bearer(self) -> str:
         token = self.oauth_token.get().strip()
@@ -187,7 +205,7 @@ class CodexWindowsApp:
             return key
         raise RuntimeError("Provide OPENAI_API_KEY or login via OpenAI OAuth.")
 
-    def _set_model_options(self, models: list[str]) -> None:
+    def _set_model_options(self, models: List[str]) -> None:
         cleaned = sorted({m.strip() for m in models if m and m.strip()})
         if not cleaned:
             cleaned = MODEL_FALLBACK
@@ -202,24 +220,22 @@ class CodexWindowsApp:
             messagebox.showerror("Missing credentials", str(exc))
             return
 
-        self._set_status("Refreshing models from OpenAI...")
+        self._set_status("Refreshing models...")
         self._set_busy(True)
         threading.Thread(target=self._refresh_models_worker, args=(bearer,), daemon=True).start()
 
     def _refresh_models_worker(self, bearer: str) -> None:
         try:
             models = _fetch_models(bearer)
-            codex_first = sorted([m for m in models if "codex" in m.lower()])
-            others = sorted([m for m in models if "codex" not in m.lower()])
-            combined = codex_first + others
-            self.root.after(0, lambda: self._set_model_options(combined))
-            if codex_first and self.model.get() not in codex_first:
-                self.root.after(0, lambda: self.model.set(codex_first[0]))
-            self._set_status(f"Models refreshed: {len(combined)} loaded")
-            self._log(f"[Models] Loaded {len(combined)} models from OpenAI.")
+            ordered = _codex_first(models)
+            self.root.after(0, lambda: self._set_model_options(ordered))
+            if ordered and not self.model.get().strip():
+                self.root.after(0, lambda: self.model.set(ordered[0]))
+            self._log(f"[Models] Loaded {len(ordered)} models from OpenAI.")
+            self._set_status("Models refreshed")
         except Exception as exc:
-            self._set_status("Model refresh failed")
             self._log(f"[Models][ERROR] {exc}")
+            self._set_status("Model refresh failed")
         finally:
             self._set_busy(False)
 
@@ -230,7 +246,7 @@ class CodexWindowsApp:
             messagebox.showerror("Missing prompt", "Please enter a prompt.")
             return
         if not model:
-            messagebox.showerror("Missing model", "Please enter a model name.")
+            messagebox.showerror("Missing model", "Please select or enter model.")
             return
 
         try:
@@ -265,37 +281,41 @@ class CodexWindowsApp:
             verifier = _create_code_verifier()
             challenge = _create_code_challenge(verifier)
             state = secrets.token_urlsafe(24)
+
             auth_params = {
                 "response_type": "code",
-                "redirect_uri": OAUTH_REDIRECT_URI,
-                "scope": OAUTH_SCOPES,
+                "redirect_uri": self.cfg.oauth_redirect_uri,
+                "scope": self.cfg.oauth_scopes,
                 "state": state,
                 "code_challenge": challenge,
                 "code_challenge_method": "S256",
             }
-            if OAUTH_CLIENT_ID:
-                auth_params["client_id"] = OAUTH_CLIENT_ID
-            launch_url = f"{OAUTH_AUTH_URL}?{parse.urlencode(auth_params)}"
+            if self.cfg.oauth_client_id:
+                auth_params["client_id"] = self.cfg.oauth_client_id
+
+            launch_url = f"{self.cfg.oauth_auth_url}?{parse.urlencode(auth_params)}"
             self._log("[OAuth] Opening browser for OpenAI sign-in...")
-            webbrowser.open(launch_url)
+            opened = webbrowser.open(launch_url)
+            if not opened:
+                self._log("[OAuth] Could not open browser automatically. Open this URL manually:")
+                self._log(launch_url)
 
             oauth = _finish_oauth_flow(
-                token_url=OAUTH_TOKEN_URL,
-                client_id=OAUTH_CLIENT_ID or None,
-                redirect_uri=OAUTH_REDIRECT_URI,
+                token_url=self.cfg.oauth_token_url,
+                client_id=self.cfg.oauth_client_id or None,
+                redirect_uri=self.cfg.oauth_redirect_uri,
                 expected_state=state,
                 code_verifier=verifier,
                 timeout_s=240,
             )
             self.root.after(0, lambda: self.oauth_token.set(oauth.access_token))
             self._log("[OAuth] Login done. Access token inserted automatically.")
-            self._set_status("OAuth login successful. Refreshing models...")
+
             models = _fetch_models(oauth.access_token)
-            codex_first = sorted([m for m in models if "codex" in m.lower()])
-            others = sorted([m for m in models if "codex" not in m.lower()])
-            self.root.after(0, lambda: self._set_model_options(codex_first + others))
-            if codex_first:
-                self.root.after(0, lambda: self.model.set(codex_first[0]))
+            ordered = _codex_first(models)
+            self.root.after(0, lambda: self._set_model_options(ordered))
+            if ordered:
+                self.root.after(0, lambda: self.model.set(ordered[0]))
             self._set_status("OAuth login successful")
         except Exception as exc:
             self._log(f"[OAuth][ERROR] {exc}")
@@ -303,6 +323,22 @@ class CodexWindowsApp:
         finally:
             self.root.after(0, lambda: self.oauth_btn.config(text="Login with OpenAI"))
             self._set_busy(False)
+
+
+def _codex_first(models: List[str]) -> List[str]:
+    codex = sorted([m for m in models if "codex" in m.lower()])
+    others = sorted([m for m in models if "codex" not in m.lower()])
+    return codex + others
+
+
+def _safe_json_loads(raw: str) -> Dict[str, Any]:
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw}
+    if isinstance(data, dict):
+        return data
+    return {"raw": data}
 
 
 def _http_json(method: str, url: str, bearer: str, body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -320,26 +356,35 @@ def _http_json(method: str, url: str, bearer: str, body: Optional[Dict[str, Any]
     except error.URLError as url_err:
         raise RuntimeError(f"Network error: {url_err}") from url_err
 
-    return json.loads(raw)
+    return _safe_json_loads(raw)
 
 
 def _fetch_models(bearer: str) -> List[str]:
     parsed = _http_json("GET", MODELS_URL, bearer)
     data = parsed.get("data", [])
-    model_ids = [item.get("id", "") for item in data if isinstance(item, dict)]
-    return [m for m in model_ids if m]
+    if not isinstance(data, list):
+        return []
+    result = []
+    for item in data:
+        if isinstance(item, dict):
+            model_id = str(item.get("id", "")).strip()
+            if model_id:
+                result.append(model_id)
+    return result
 
 
 def _call_openai(bearer: str, model: str, prompt: str) -> str:
     parsed = _http_json("POST", RESPONSES_URL, bearer, body={"model": model, "input": prompt})
     if parsed.get("output_text"):
-        return parsed["output_text"]
+        return str(parsed["output_text"])
 
-    chunks = []
+    chunks: List[str] = []
     for item in parsed.get("output", []):
+        if not isinstance(item, dict):
+            continue
         for content in item.get("content", []):
-            if content.get("type") == "output_text":
-                chunks.append(content.get("text", ""))
+            if isinstance(content, dict) and content.get("type") == "output_text":
+                chunks.append(str(content.get("text", "")))
     if chunks:
         return "".join(chunks).strip()
 
@@ -379,7 +424,7 @@ def _finish_oauth_flow(
 
 def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> Tuple[str, str]:
     parsed_redirect = parse.urlparse(redirect_uri)
-    result = {"code": None, "state": None}
+    result: Dict[str, Optional[str]] = {"code": None, "state": None}
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
@@ -392,12 +437,16 @@ def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> Tuple[str, str
             self.end_headers()
             self.wfile.write(b"<html><body><h3>Login success. You can close this tab.</h3></body></html>")
 
-        def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
             return
 
     host = parsed_redirect.hostname or "127.0.0.1"
     port = parsed_redirect.port or 80
-    server = HTTPServer((host, port), Handler)
+    try:
+        server = HTTPServer((host, port), Handler)
+    except OSError as exc:
+        raise RuntimeError(f"OAuth callback server failed on {host}:{port}. Port busy? {exc}") from exc
+
     server.timeout = 0.5
     start = time.time()
 
@@ -414,7 +463,7 @@ def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> Tuple[str, str
 
 
 def _exchange_oauth_token(token_url: str, client_id: Optional[str], code: str, redirect_uri: str, code_verifier: str) -> str:
-    payload = {
+    payload: Dict[str, str] = {
         "grant_type": "authorization_code",
         "code": code,
         "redirect_uri": redirect_uri,
@@ -422,6 +471,7 @@ def _exchange_oauth_token(token_url: str, client_id: Optional[str], code: str, r
     }
     if client_id:
         payload["client_id"] = client_id
+
     req = request.Request(token_url, data=parse.urlencode(payload).encode("utf-8"), method="POST")
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
 
@@ -434,11 +484,11 @@ def _exchange_oauth_token(token_url: str, client_id: Optional[str], code: str, r
     except error.URLError as url_err:
         raise RuntimeError(f"Network error during OAuth token exchange: {url_err}") from url_err
 
-    parsed = json.loads(raw)
+    parsed = _safe_json_loads(raw)
     token = parsed.get("access_token")
     if not token:
         raise RuntimeError(f"OAuth token response has no access_token: {parsed}")
-    return token
+    return str(token)
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -1,0 +1,451 @@
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+import tkinter as tk
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from tkinter import messagebox, scrolledtext, ttk
+from urllib import error, parse, request
+
+API_BASE = "https://api.openai.com/v1"
+RESPONSES_URL = f"{API_BASE}/responses"
+MODELS_URL = f"{API_BASE}/models"
+
+DEFAULT_MODEL = "gpt-5-codex"
+MODEL_FALLBACK = [
+    "gpt-5-codex",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "o4-mini",
+]
+
+# OAuth defaults. Client ID must be provided via env.
+OAUTH_CLIENT_ID = os.getenv("OPENAI_OAUTH_CLIENT_ID", "").strip()
+OAUTH_AUTH_URL = os.getenv("OPENAI_OAUTH_AUTH_URL", "https://auth.openai.com/oauth/authorize").strip()
+OAUTH_TOKEN_URL = os.getenv("OPENAI_OAUTH_TOKEN_URL", "https://auth.openai.com/oauth/token").strip()
+OAUTH_SCOPES = os.getenv("OPENAI_OAUTH_SCOPES", "openid profile email").strip()
+OAUTH_REDIRECT_URI = os.getenv("OPENAI_OAUTH_REDIRECT_URI", "http://127.0.0.1:8765/callback").strip()
+
+
+@dataclass
+class OAuthResult:
+    access_token: str
+    state: str
+
+
+class CodexWindowsApp:
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("OpenAI Codex for Windows")
+        self.root.geometry("1120x780")
+        self.root.minsize(860, 620)
+        self.root.configure(bg="#0f172a")
+
+        self.api_key = tk.StringVar(value=os.getenv("OPENAI_API_KEY", ""))
+        self.oauth_token = tk.StringVar(value=os.getenv("OPENAI_OAUTH_TOKEN", ""))
+        self.model = tk.StringVar(value=os.getenv("OPENAI_MODEL", DEFAULT_MODEL))
+        self.status = tk.StringVar(value="Ready")
+
+        self._configure_theme()
+        self._build_ui()
+        self._set_model_options(MODEL_FALLBACK)
+
+    def _configure_theme(self) -> None:
+        style = ttk.Style(self.root)
+        if "clam" in style.theme_names():
+            style.theme_use("clam")
+
+        style.configure("Card.TFrame", background="#111827")
+        style.configure("Title.TLabel", background="#111827", foreground="#e5e7eb", font=("Segoe UI", 12, "bold"))
+        style.configure("Label.TLabel", background="#111827", foreground="#cbd5e1", font=("Segoe UI", 10))
+        style.configure("Accent.TButton", font=("Segoe UI", 10, "bold"))
+
+    def _build_ui(self) -> None:
+        outer = ttk.Frame(self.root, style="Card.TFrame", padding=14)
+        outer.pack(fill=tk.BOTH, expand=True)
+
+        header = ttk.Frame(outer, style="Card.TFrame")
+        header.pack(fill=tk.X, pady=(0, 10))
+        ttk.Label(header, text="OpenAI Codex Desktop", style="Title.TLabel").pack(side=tk.LEFT)
+        ttk.Label(header, text="Windows • One-click OAuth • Auto-model sync", style="Label.TLabel").pack(side=tk.RIGHT)
+
+        cred = ttk.LabelFrame(outer, text="Authorization", padding=10)
+        cred.pack(fill=tk.X, pady=(0, 10))
+
+        ttk.Label(cred, text="OAuth Access Token", style="Label.TLabel").grid(row=0, column=0, sticky="w")
+        ttk.Entry(cred, textvariable=self.oauth_token, show="*", width=68).grid(row=0, column=1, sticky="ew", padx=8)
+        self.oauth_btn = ttk.Button(cred, text="Login with OpenAI", style="Accent.TButton", command=self.start_oauth)
+        self.oauth_btn.grid(row=0, column=2, sticky="w")
+
+        ttk.Label(cred, text="API Key (fallback)", style="Label.TLabel").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        ttk.Entry(cred, textvariable=self.api_key, show="*", width=68).grid(row=1, column=1, sticky="ew", padx=8, pady=(8, 0))
+        ttk.Button(cred, text="Clear tokens", command=self.clear_tokens).grid(row=1, column=2, sticky="w", pady=(8, 0))
+        cred.columnconfigure(1, weight=1)
+
+        config = ttk.LabelFrame(outer, text="Model + Prompt", padding=10)
+        config.pack(fill=tk.BOTH, expand=True)
+
+        top_row = ttk.Frame(config)
+        top_row.pack(fill=tk.X, pady=(0, 8))
+
+        ttk.Label(top_row, text="Model", style="Label.TLabel").pack(side=tk.LEFT)
+        self.model_box = ttk.Combobox(top_row, textvariable=self.model, width=28)
+        self.model_box.pack(side=tk.LEFT, padx=(8, 10))
+        self.refresh_models_btn = ttk.Button(top_row, text="Refresh models", command=self.refresh_models)
+        self.refresh_models_btn.pack(side=tk.LEFT)
+
+        self.run_btn = ttk.Button(top_row, text="Run", style="Accent.TButton", command=self.ask_model)
+        self.run_btn.pack(side=tk.RIGHT)
+        ttk.Button(top_row, text="Clear Output", command=self.clear_output).pack(side=tk.RIGHT, padx=6)
+
+        ttk.Label(config, text="Prompt", style="Label.TLabel").pack(anchor="w")
+        self.prompt = scrolledtext.ScrolledText(
+            config,
+            height=10,
+            wrap=tk.WORD,
+            bg="#0b1220",
+            fg="#d1d5db",
+            insertbackground="#f8fafc",
+            relief=tk.FLAT,
+            padx=8,
+            pady=8,
+        )
+        self.prompt.pack(fill=tk.BOTH, expand=False)
+
+        ttk.Label(config, text="Response / Logs", style="Label.TLabel").pack(anchor="w", pady=(8, 0))
+        self.output = scrolledtext.ScrolledText(
+            config,
+            wrap=tk.WORD,
+            state=tk.DISABLED,
+            bg="#020617",
+            fg="#dbeafe",
+            insertbackground="#f8fafc",
+            relief=tk.FLAT,
+            padx=8,
+            pady=8,
+        )
+        self.output.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(
+            outer,
+            text=(
+                "Tip: натисни Refresh models після OAuth — список підтягнеться автоматично з /v1/models "
+                "і покаже актуальні Codex-моделі."
+            ),
+            style="Label.TLabel",
+        ).pack(fill=tk.X, pady=(8, 0))
+
+        footer = ttk.Label(outer, textvariable=self.status, style="Label.TLabel")
+        footer.pack(fill=tk.X, pady=(6, 0))
+
+    def clear_tokens(self) -> None:
+        self.oauth_token.set("")
+        self.api_key.set("")
+        self._set_status("Tokens cleared")
+
+    def clear_output(self) -> None:
+        self.output.config(state=tk.NORMAL)
+        self.output.delete("1.0", tk.END)
+        self.output.config(state=tk.DISABLED)
+        self._set_status("Output cleared")
+
+    def _set_status(self, text: str) -> None:
+        self.root.after(0, lambda: self.status.set(text))
+
+    def _log(self, text: str) -> None:
+        def update() -> None:
+            self.output.config(state=tk.NORMAL)
+            self.output.insert(tk.END, f"{text}\n")
+            self.output.see(tk.END)
+            self.output.config(state=tk.DISABLED)
+
+        self.root.after(0, update)
+
+    def _set_busy(self, busy: bool) -> None:
+        state = tk.DISABLED if busy else tk.NORMAL
+        self.root.after(0, lambda: self.run_btn.config(state=state))
+        self.root.after(0, lambda: self.oauth_btn.config(state=state if not busy else tk.DISABLED))
+        self.root.after(0, lambda: self.refresh_models_btn.config(state=state))
+
+    def _resolve_bearer(self) -> str:
+        token = self.oauth_token.get().strip()
+        key = self.api_key.get().strip()
+        if token:
+            return token
+        if key:
+            return key
+        raise RuntimeError("Provide OPENAI_API_KEY or login via OpenAI OAuth.")
+
+    def _set_model_options(self, models: list[str]) -> None:
+        cleaned = sorted({m.strip() for m in models if m and m.strip()})
+        if not cleaned:
+            cleaned = MODEL_FALLBACK
+        self.model_box["values"] = cleaned
+        if not self.model.get().strip():
+            self.model.set(cleaned[0])
+
+    def refresh_models(self) -> None:
+        try:
+            bearer = self._resolve_bearer()
+        except Exception as exc:
+            messagebox.showerror("Missing credentials", str(exc))
+            return
+
+        self._set_status("Refreshing models from OpenAI...")
+        self._set_busy(True)
+        threading.Thread(target=self._refresh_models_worker, args=(bearer,), daemon=True).start()
+
+    def _refresh_models_worker(self, bearer: str) -> None:
+        try:
+            models = _fetch_models(bearer)
+            codex_first = sorted([m for m in models if "codex" in m.lower()])
+            others = sorted([m for m in models if "codex" not in m.lower()])
+            combined = codex_first + others
+            self.root.after(0, lambda: self._set_model_options(combined))
+            if codex_first and self.model.get() not in codex_first:
+                self.root.after(0, lambda: self.model.set(codex_first[0]))
+            self._set_status(f"Models refreshed: {len(combined)} loaded")
+            self._log(f"[Models] Loaded {len(combined)} models from OpenAI.")
+        except Exception as exc:
+            self._set_status("Model refresh failed")
+            self._log(f"[Models][ERROR] {exc}")
+        finally:
+            self._set_busy(False)
+
+    def ask_model(self) -> None:
+        prompt = self.prompt.get("1.0", tk.END).strip()
+        model = self.model.get().strip()
+        if not prompt:
+            messagebox.showerror("Missing prompt", "Please enter a prompt.")
+            return
+        if not model:
+            messagebox.showerror("Missing model", "Please enter a model name.")
+            return
+
+        try:
+            bearer = self._resolve_bearer()
+        except Exception as exc:
+            messagebox.showerror("Missing credentials", str(exc))
+            return
+
+        self._set_status("Request in progress...")
+        self._set_busy(True)
+        threading.Thread(target=self._worker, args=(bearer, model, prompt), daemon=True).start()
+
+    def _worker(self, bearer: str, model: str, prompt: str) -> None:
+        try:
+            answer = _call_openai(bearer, model, prompt)
+            self._log(f"\n>>> {model}\n{answer}\n")
+            self._set_status("Request completed")
+        except Exception as exc:
+            self._log(f"\n[ERROR] {exc}\n")
+            self._set_status("Request failed")
+        finally:
+            self._set_busy(False)
+
+    def start_oauth(self) -> None:
+        if not OAUTH_CLIENT_ID:
+            messagebox.showerror(
+                "Missing OAuth client",
+                "Set OPENAI_OAUTH_CLIENT_ID in Windows environment variables and restart app.",
+            )
+            return
+
+        self._set_busy(True)
+        self.root.after(0, lambda: self.oauth_btn.config(text="Waiting OAuth..."))
+        self._set_status("OAuth login started...")
+        threading.Thread(target=self._oauth_worker, daemon=True).start()
+
+    def _oauth_worker(self) -> None:
+        try:
+            verifier = _create_code_verifier()
+            challenge = _create_code_challenge(verifier)
+            state = secrets.token_urlsafe(24)
+            auth_params = {
+                "response_type": "code",
+                "client_id": OAUTH_CLIENT_ID,
+                "redirect_uri": OAUTH_REDIRECT_URI,
+                "scope": OAUTH_SCOPES,
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            }
+            launch_url = f"{OAUTH_AUTH_URL}?{parse.urlencode(auth_params)}"
+            self._log("[OAuth] Opening browser for OpenAI sign-in...")
+            webbrowser.open(launch_url)
+
+            oauth = _finish_oauth_flow(
+                token_url=OAUTH_TOKEN_URL,
+                client_id=OAUTH_CLIENT_ID,
+                redirect_uri=OAUTH_REDIRECT_URI,
+                expected_state=state,
+                code_verifier=verifier,
+                timeout_s=240,
+            )
+            self.root.after(0, lambda: self.oauth_token.set(oauth.access_token))
+            self._log("[OAuth] Login done. Access token inserted automatically.")
+            self._set_status("OAuth login successful. Refreshing models...")
+            models = _fetch_models(oauth.access_token)
+            codex_first = sorted([m for m in models if "codex" in m.lower()])
+            others = sorted([m for m in models if "codex" not in m.lower()])
+            self.root.after(0, lambda: self._set_model_options(codex_first + others))
+            if codex_first:
+                self.root.after(0, lambda: self.model.set(codex_first[0]))
+            self._set_status("OAuth login successful")
+        except Exception as exc:
+            self._log(f"[OAuth][ERROR] {exc}")
+            self._set_status("OAuth login failed")
+        finally:
+            self.root.after(0, lambda: self.oauth_btn.config(text="Login with OpenAI"))
+            self._set_busy(False)
+
+
+def _http_json(method: str, url: str, bearer: str, body: dict | None = None) -> dict:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    req = request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {bearer}")
+    req.add_header("Content-Type", "application/json")
+
+    try:
+        with request.urlopen(req, timeout=120) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as http_err:
+        detail = http_err.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {http_err.code}: {detail}") from http_err
+    except error.URLError as url_err:
+        raise RuntimeError(f"Network error: {url_err}") from url_err
+
+    return json.loads(raw)
+
+
+def _fetch_models(bearer: str) -> list[str]:
+    parsed = _http_json("GET", MODELS_URL, bearer)
+    data = parsed.get("data", [])
+    model_ids = [item.get("id", "") for item in data if isinstance(item, dict)]
+    return [m for m in model_ids if m]
+
+
+def _call_openai(bearer: str, model: str, prompt: str) -> str:
+    parsed = _http_json("POST", RESPONSES_URL, bearer, body={"model": model, "input": prompt})
+    if parsed.get("output_text"):
+        return parsed["output_text"]
+
+    chunks = []
+    for item in parsed.get("output", []):
+        for content in item.get("content", []):
+            if content.get("type") == "output_text":
+                chunks.append(content.get("text", ""))
+    if chunks:
+        return "".join(chunks).strip()
+
+    return json.dumps(parsed, indent=2, ensure_ascii=False)
+
+
+def _create_code_verifier() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(64)).decode("utf-8").rstrip("=")
+
+
+def _create_code_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+
+
+def _finish_oauth_flow(
+    token_url: str,
+    client_id: str,
+    redirect_uri: str,
+    expected_state: str,
+    code_verifier: str,
+    timeout_s: int,
+) -> OAuthResult:
+    code, returned_state = _wait_for_callback_code(redirect_uri, timeout_s)
+    if returned_state and returned_state != expected_state:
+        raise RuntimeError("OAuth state mismatch. Please retry.")
+
+    token = _exchange_oauth_token(
+        token_url=token_url,
+        client_id=client_id,
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+    )
+    return OAuthResult(access_token=token, state=returned_state)
+
+
+def _wait_for_callback_code(redirect_uri: str, timeout_s: int) -> tuple[str, str]:
+    parsed_redirect = parse.urlparse(redirect_uri)
+    result = {"code": None, "state": None}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            q = parse.urlparse(self.path)
+            params = parse.parse_qs(q.query)
+            result["code"] = params.get("code", [None])[0]
+            result["state"] = params.get("state", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"<html><body><h3>Login success. You can close this tab.</h3></body></html>")
+
+        def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+            return
+
+    host = parsed_redirect.hostname or "127.0.0.1"
+    port = parsed_redirect.port or 80
+    server = HTTPServer((host, port), Handler)
+    server.timeout = 0.5
+    start = time.time()
+
+    while time.time() - start < timeout_s:
+        server.handle_request()
+        if result["code"]:
+            break
+
+    server.server_close()
+    if not result["code"]:
+        raise RuntimeError(f"OAuth callback timeout for {redirect_uri}")
+
+    return str(result["code"]), str(result["state"] or "")
+
+
+def _exchange_oauth_token(token_url: str, client_id: str, code: str, redirect_uri: str, code_verifier: str) -> str:
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+    }
+    req = request.Request(token_url, data=parse.urlencode(payload).encode("utf-8"), method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with request.urlopen(req, timeout=60) as response:
+            raw = response.read().decode("utf-8")
+    except error.HTTPError as http_err:
+        detail = http_err.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OAuth token exchange failed ({http_err.code}): {detail}") from http_err
+    except error.URLError as url_err:
+        raise RuntimeError(f"Network error during OAuth token exchange: {url_err}") from url_err
+
+    parsed = json.loads(raw)
+    token = parsed.get("access_token")
+    if not token:
+        raise RuntimeError(f"OAuth token response has no access_token: {parsed}")
+    return token
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = CodexWindowsApp(root)
+    root.mainloop()

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+where pyinstaller >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo [ERROR] PyInstaller is not installed.
+  echo Install with: py -m pip install pyinstaller
+  exit /b 1
+)
+
+pyinstaller --noconfirm --onefile --windowed --name OpenAI-Codex-Windows app.py
+
+echo.
+echo Build completed. Executable is in dist\OpenAI-Codex-Windows.exe
+endlocal

--- a/run_windows.bat
+++ b/run_windows.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+if "%OPENAI_API_KEY%"=="" (
+    echo [INFO] OPENAI_API_KEY is not set. You can still type it in the app.
+)
+
+python app.py
+endlocal


### PR DESCRIPTION
### Motivation

- Provide a simple Windows desktop client for OpenAI Codex with one-click OAuth and a friendly UI. 
- Automatically fetch available models from the OpenAI `GET /v1/models` endpoint and prioritize `codex` models. 
- Offer an API key fallback and easy packaging/run workflows for Windows users.

### Description

- Add `app.py` which implements the `CodexWindowsApp` Tkinter GUI, interactive prompt/response panes, model selector, and status/log output, and contains the main entrypoint. 
- Implement OAuth PKCE login and local callback handling with helper functions ` _create_code_verifier`, `_create_code_challenge`, `_finish_oauth_flow`, `_wait_for_callback_code`, and `_exchange_oauth_token` that auto-insert the access token into the app. 
- Add network helpers `_http_json`, `_fetch_models`, and `_call_openai` to communicate with `https://api.openai.com/v1` for model listing and `responses` calls, and implement API key fallback via `OPENAI_API_KEY`. 
- Update `README.md` with usage instructions, env vars, model behavior, and packaging steps, and add `build_windows.bat` and `run_windows.bat` to simplify running and building the executable on Windows.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48cb596bc8322bbda05a3108f000b)